### PR TITLE
fix: do not set empty authorization header

### DIFF
--- a/internal/htsdao/urldao.go
+++ b/internal/htsdao/urldao.go
@@ -34,7 +34,9 @@ func (dao *URLDao) GetContentLength(request *http.Request) int64 {
 		return contentLength
 	}
 	req, err := http.NewRequest("HEAD", dao.url, nil)
-	req.Header.Set("Authorization", request.Header.Get("Authorization"))
+	if request.Header.Get("Authorization") != "" {
+		req.Header.Set("Authorization", request.Header.Get("Authorization"))
+	}
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Errorf("error getting the head, %v", err)

--- a/internal/htsdao/urldao.go
+++ b/internal/htsdao/urldao.go
@@ -34,6 +34,11 @@ func (dao *URLDao) GetContentLength(request *http.Request) int64 {
 		return contentLength
 	}
 	req, err := http.NewRequest("HEAD", dao.url, nil)
+	if err != nil {
+		log.Errorf("error creating the request, %v", err)
+		
+		return 0
+	}
 	if request.Header.Get("Authorization") != "" {
 		req.Header.Set("Authorization", request.Header.Get("Authorization"))
 	}


### PR DESCRIPTION
Fixes the issue where samtools failed at reading from a public S3 backend (likely due to the empty header value messing up some parsing).