### PR TITLE
return full file when requesting a region

### DIFF
--- a/internal/htsrequest/request.go
+++ b/internal/htsrequest/request.go
@@ -335,6 +335,8 @@ func (r *HtsgetRequest) ConstructDataEndpointURL(useRegion bool, regionI int) (s
 		query.Set("class", r.GetClass())
 	}
 
+	useRegion = false // temporary solution: return full file when doing partial request
+
 	if useRegion {
 		region := r.GetRegions()[regionI]
 		if region.ReferenceNameRequested() {


### PR DESCRIPTION
This PR closes https://github.com/GenomicDataInfrastructure/starter-kit-htsget/issues/6

**Changes made**
The htsget server returns the full file when a user request parts of it. 
> Note that this is just a temporary solution since the partial request functionality is still not ready for the `htsget-refserver`.

with this change, all the following commands 
```bash
samtools view  http://localhost:3000/reads/s3/NA12878_20k_b37.bam
samtools view "http://localhost:3000/reads/s3/NA12878_20k_b37.bam?referenceName=1&start=10000&end=12000"
htsget --format bam --output out.bam --reference-name 1 --start 10000 --end 12000 http://localhost:3000/reads/s3/NA12878_20k_b37.bam 
``` 
return the complete content of the requested BAM file. 

**further commens**
I tried to fix the partial retrieving functionality but it seems not that easy. 

